### PR TITLE
バッグエンド環境構築

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,0 +1,17 @@
+#ベースイメージとして公式のPythonイメージを使用
+FROM python:3.9-slim
+
+#作業ディレクトリを設定
+WORKDIR /app
+
+#必要なパッケージをインストール
+COPY requirements.txt .
+
+#pipを使用してPythonパッケージをインストール
+RUN pip install --no-cache-dir -r requirements.txt
+
+#アプリケーションのソースコードをコピー
+COPY . .
+
+# FastAPIのサーバーを起動
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/back/requirements.txt
+++ b/back/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+scikit-learn


### PR DESCRIPTION
## バックエンド環境構築
バッグエンド側のDockerfileと必要なライブラリが書き込まれたrequirements.txtを追加しました。

yamlのやつはまだ作ってないのと、dockerhubにまだあげてません。

```
docker build -t my-fastapi-app .

```

恐らくこれでローカルの8080ポートでアクセスできるはずです。僕はそれでいけました。
